### PR TITLE
Fix responsive width for StreamingText

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -93,7 +93,8 @@ button:disabled {
 }
 
 .text-stream pre {
-  width: 640px;
+  width: 100%;
+  max-width: 640px;
   height: 360px;
   color: #ffffff;
   font-family: monospace;
@@ -116,7 +117,8 @@ button:disabled {
 }
 
 .text-stream pre {
-  width: 640px;
+  width: 100%;
+  max-width: 640px;
   height: 360px;
   color: #ffffff;
   font-family: monospace;


### PR DESCRIPTION
## Summary
- ensure StreamingText fits inside mobile width by updating CSS

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b30d4a3a8832f88709c87d1d5ede2