### PR TITLE
Enable interactive web app messages

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -105,6 +105,13 @@ button:disabled {
   white-space: pre-wrap;
 }
 
+.generated-iframe {
+  width: 100%;
+  max-width: 640px;
+  height: 360px;
+  border: none;
+}
+
 .status-controls {
   display: flex;
   align-items: center;

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -5,7 +5,7 @@ import { ConnectButton } from '../components/ConnectButton';
 import { MicToggleButton } from '../components/MicToggleButton';
 import { StatusDisplay } from '../components/StatusDisplay';
 import { DebugDisplay } from '../components/DebugDisplay';
-import { StreamingText } from '../components/StreamingText';
+import { StreamingDisplay } from '../components/StreamingDisplay';
 
 export default function Home() {
   return (
@@ -19,7 +19,7 @@ export default function Home() {
       </div>
 
       <div className="main-content">
-        <StreamingText />
+        <StreamingDisplay />
       </div>
 
       <DebugDisplay />

--- a/client/src/components/GeneratedCodeIframe.tsx
+++ b/client/src/components/GeneratedCodeIframe.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface GeneratedCodeIframeProps {
+  code: string;
+}
+
+export function GeneratedCodeIframe({ code }: GeneratedCodeIframeProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    if (!iframeRef.current) return;
+    const doc = iframeRef.current.contentDocument;
+    if (!doc) return;
+    doc.open();
+    doc.write(code);
+    doc.close();
+  }, [code]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      className="generated-iframe"
+      sandbox="allow-scripts allow-same-origin"
+    />
+  );
+}

--- a/client/src/components/StreamingDisplay.tsx
+++ b/client/src/components/StreamingDisplay.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { RTVIEvent } from '@pipecat-ai/client-js';
+import { useRTVIClientEvent } from '@pipecat-ai/client-react';
+import { GeneratedCodeIframe } from './GeneratedCodeIframe';
+
+interface ServerMessage {
+  'clear-pre-text'?: boolean;
+  'display-pre-text'?: string;
+  'web-application-start'?: boolean;
+  'web-application-thinking'?: string;
+  'web-application-code'?: string;
+  'web-application-end'?: boolean;
+}
+
+export function StreamingDisplay() {
+  const textRef = useRef<HTMLPreElement>(null);
+  const codeBuffer = useRef<string>('');
+  const [iframeCode, setIframeCode] = useState<string | null>(null);
+
+  const handleClear = () => {
+    if (textRef.current) {
+      textRef.current.textContent = '';
+    }
+  };
+
+  const showText = iframeCode === null;
+
+  const handleMessage = useCallback((message: ServerMessage) => {
+    if (!textRef.current) return;
+
+    if (message['clear-pre-text'] === true) {
+      setIframeCode(null);
+      textRef.current.textContent = '';
+      return;
+    }
+
+    if (typeof message['display-pre-text'] === 'string') {
+      setIframeCode(null);
+      textRef.current.textContent += message['display-pre-text'];
+      textRef.current.scrollTop = textRef.current.scrollHeight;
+      return;
+    }
+
+    if (message['web-application-start']) {
+      setIframeCode(null);
+      codeBuffer.current = '';
+      textRef.current.textContent = '';
+      return;
+    }
+
+    if (typeof message['web-application-thinking'] === 'string') {
+      textRef.current.textContent += message['web-application-thinking'];
+      textRef.current.scrollTop = textRef.current.scrollHeight;
+      return;
+    }
+
+    if (typeof message['web-application-code'] === 'string') {
+      textRef.current.textContent += message['web-application-code'];
+      codeBuffer.current += message['web-application-code'];
+      textRef.current.scrollTop = textRef.current.scrollHeight;
+      return;
+    }
+
+    if (message['web-application-end']) {
+      setIframeCode(codeBuffer.current);
+      return;
+    }
+  }, []);
+
+  useRTVIClientEvent(RTVIEvent.ServerMessage, handleMessage);
+
+  return (
+    <div className="text-stream">
+      {showText ? (
+        <>
+          <pre ref={textRef} style={{ backgroundColor: 'black' }} />
+          <button onClick={handleClear}>Clear</button>
+        </>
+      ) : (
+        <GeneratedCodeIframe code={iframeCode ?? ''} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add GeneratedCodeIframe to run code in sandbox
- add StreamingDisplay component to handle web-application messages and show either streaming text or iframe
- update main page to use StreamingDisplay
- style iframe in global CSS

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b4fb32cd8832fa26ecd455ddb043d